### PR TITLE
Various features to support th eopus-ui builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "1.8.15",
+	"version": "1.9.0",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
 	"files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "1.8.3",
+	"version": "1.8.15",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
 	"files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "1.8.0",
+	"version": "1.8.3",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
 	"files": [

--- a/src/components/scriptRunner/actions/getComponentAtPosition.js
+++ b/src/components/scriptRunner/actions/getComponentAtPosition.js
@@ -10,10 +10,11 @@ const getComponentAtPosition = ({ x, y }) => {
 	document
 		.elementsFromPoint(x, y)
 		.forEach(e => {
-			const useId = e.classList.contains('popoverRef') ? e.parentNode.id : e.id;
+			if (e.classList.contains('popoverRef'))
+				return;
 
-			if (dom.some(d => d.id === useId))
-				res.push(useId);
+			if (dom.some(d => d.id === e.id))
+				res.push(e.id);
 		});
 
 	return res;

--- a/src/components/scriptRunner/actions/getMda/getMda.js
+++ b/src/components/scriptRunner/actions/getMda/getMda.js
@@ -5,6 +5,7 @@ import { mergeMap, retry } from 'rxjs/operators';
 
 //System Helpers
 import { getItem, addItem } from '../../../../system/managers/localStorageManager';
+import { clone } from '../../../../system/helpers';
 import buildFileUrl from './buildFileUrl';
 
 //Config
@@ -124,18 +125,17 @@ export const getMdaHelper = action => {
 
 export const setMdaPackage = packageContents => {
 	if (!mdaPackage.contents) {
-		mdaPackage.contents = { dashboard: {}, theme: {} };
+		mdaPackage.contents = { dashboard: {}, data: {}, theme: {} };
 	}
-	Object.entries(packageContents).forEach(([k, v]) => {
-		Object.assign(mdaPackage.contents[k], v);
-	});
+
+	clone(mdaPackage.contents, packageContents);
 
 	mdaPackage.loaded = true;
 };
 
 export const loadEnsemble = ({ name, ensemble }) => {
 	if (!mdaPackage.contents)
-		mdaPackage.contents = { dashboard: {}, theme: {} };
+		mdaPackage.contents = { dashboard: {}, data: {}, theme: {} };
 
 	mdaPackage.contents.dashboard[name] = ensemble.dashboard;
 
@@ -151,7 +151,7 @@ export const loadEnsemble = ({ name, ensemble }) => {
 
 export const addMdaPackage = ({ path, contents }) => {
 	if (!mdaPackage.contents)
-		mdaPackage.contents = { dashboard: {}, theme: {} };
+		mdaPackage.contents = { dashboard: {}, data: {}, theme: {} };
 
 	contents = JSON.parse(
 		JSON.stringify(contents)

--- a/src/components/scriptRunner/actions/getMda/getMda.js
+++ b/src/components/scriptRunner/actions/getMda/getMda.js
@@ -137,7 +137,16 @@ export const loadEnsemble = ({ name, ensemble }) => {
 	if (!mdaPackage.contents)
 		mdaPackage.contents = { dashboard: {}, theme: {} };
 
-	mdaPackage.contents.dashboard[name] = ensemble;
+	mdaPackage.contents.dashboard[name] = ensemble.dashboard;
+
+	if (ensemble.themes) {
+		Object.entries(ensemble.themes).forEach(([k, v]) => {
+			if (mdaPackage.contents.theme[k])
+				Object.assign(mdaPackage.contents.theme[k], v);
+			else
+				mdaPackage.contents.theme[k] = v;
+		});
+	}
 };
 
 export const addMdaPackage = ({ path, contents }) => {

--- a/src/components/scriptRunner/config/configTriggers.js
+++ b/src/components/scriptRunner/config/configTriggers.js
@@ -266,6 +266,33 @@ const triggers = [
 		]
 	},
 	{
+		key: 'onGlobalKeyUp',
+		desc: 'A trigger which will fire when any key is de-pressed on the keyboard, which is outside the context of this component',
+		type: 'string',
+		keys: [
+			{
+				key: 'source',
+				desc: 'The id (static or scoped) of the component that the trigger will listen on',
+				type: 'string'
+			},
+			{
+				key: 'match',
+				desc: 'A list of comparisons that are matched against, when determining if the trigger should run',
+				type: 'array'
+			},
+			{
+				key: 'matchEvaluation',
+				desc: 'A type of evaluation that should be performed for the match e.g. "some", "none" etc',
+				type: 'string'
+			},
+			{
+				key: 'consumeEventOnUse',
+				desc: 'When set to true, the event will consume. For example, when consuming F5, the browser will not refresh',
+				type: 'boolean'
+			}
+		]
+	},
+	{
 		key: 'onFocus',
 		desc: 'A trigger which will fire when a component is focused',
 		type: 'string',

--- a/src/components/scriptRunner/triggers.js
+++ b/src/components/scriptRunner/triggers.js
@@ -21,7 +21,7 @@ export { default as onUnmount } from './triggers/onUnmount';
 export { default as onWindowResized } from './triggers/onWindowResized';
 
 export {
-	onKeyDown, onGlobalKeyDown
+	onKeyDown, onGlobalKeyDown, onGlobalKeyUp
 } from './triggers/keyTriggers';
 
 const subToTag = (morphedConfig, props, script, context) => {

--- a/src/components/scriptRunner/triggers/keyTriggers.js
+++ b/src/components/scriptRunner/triggers/keyTriggers.js
@@ -117,3 +117,27 @@ export const onGlobalKeyDown = (config, props, script, context) => {
 
 	return unsubs;
 };
+
+export const onGlobalKeyUp = (config, props, script, context) => {
+	const consumeEventOnUse = config.consumeEventOnUse ?? false;
+
+	const unsubs = subscribeToGlobalEvent('onGlobalKeyUp', script.ownerId, e => {
+		if (!shouldFire(config, props, script, e))
+			return false;
+
+		initAndRunScript({
+			script,
+			props,
+			context,
+			setVariables: {
+				triggeredKey: e.key,
+				triggeredKeyCode: e.keyCode
+			},
+			isRootScript: true
+		});
+
+		return consumeEventOnUse;
+	});
+
+	return unsubs;
+};

--- a/src/components/wrapWidgets.js
+++ b/src/components/wrapWidgets.js
@@ -2,7 +2,19 @@
 import React from 'react';
 
 const wrapWidgets = ({ ChildWgt, wgts = [] }) => {
-	const result = wgts.map(w => <ChildWgt key={w.id} mda={w} />);
+	const result = wgts.map((w, i) => {
+		if (!w.prps)
+			w.prps = {};
+
+		w.prps.indexInParent = i;
+
+		return (
+			<ChildWgt
+				key={w.id}
+				mda={w}
+			/>
+		);
+	});
 
 	return result;
 };

--- a/src/library.js
+++ b/src/library.js
@@ -25,7 +25,7 @@ export {
 } from './components/scriptRunner/actions';
 export { applyComparison } from './components/scriptRunner/actions';
 export { default as initAndRunScript } from './components/scriptRunner/helpers/initAndRunScript';
-export { addMdaPackage as loadMdaPackage, getMdaPackage } from './components/scriptRunner/actions/getMda/getMda';
+export { addMdaPackage as loadMdaPackage, getMdaPackage, setMdaPackage } from './components/scriptRunner/actions/getMda/getMda';
 export { loadEnsemble, getMdaHelper as getMda, setMdaAtPath } from './components/scriptRunner/actions/getMda/getMda';
 export {
 	default as morphConfig, fixScopeIds
@@ -62,7 +62,7 @@ export { resolveThemeAccessor } from './system/managers/themeManager';
 
 export { default as useEffectSkipFirst } from './system/customHooks/useEffectSkipFirst';
 
-export { getScopedId } from './system/managers/scopeManager';
+export { getScopedId, getDom } from './system/managers/scopeManager';
 
 export { default as propsSharedContainer } from './components/container/propsShared';
 
@@ -76,7 +76,7 @@ export { default as dateFormatter } from './helpers/dateFormatter';
 
 export { format } from './components/helpers';
 
-export { getPropSpecs } from './system/managers/componentManager';
+export { getPropSpecs, applyPropSpecDefaults, getComponentTypes } from './system/managers/componentManager';
 export { default as componentBaseProps } from './components/baseProps';
 
 export { default as validate } from './validation/validate';

--- a/src/library.js
+++ b/src/library.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 //Helpers
 import applyThemesToMdaPackage from './app/components/helpers/applyThemesToMdaPackage';
+export { default as applyThemesToMdaPackage } from './app/components/helpers/applyThemesToMdaPackage';
 
 //System
 import { Wrapper } from './system/wrapper/wrapper';
@@ -29,6 +30,7 @@ export { loadEnsemble, getMdaHelper as getMda, setMdaAtPath } from './components
 export {
 	default as morphConfig, fixScopeIds
 } from './components/scriptRunner/helpers/morphConfig';
+export { buildThemes } from './app/components/themeLoader';
 
 export {
 	getThemeValue, getThemes

--- a/src/library.js
+++ b/src/library.js
@@ -26,7 +26,7 @@ export {
 export { applyComparison } from './components/scriptRunner/actions';
 export { default as initAndRunScript } from './components/scriptRunner/helpers/initAndRunScript';
 export { addMdaPackage as loadMdaPackage, getMdaPackage, setMdaPackage } from './components/scriptRunner/actions/getMda/getMda';
-export { loadEnsemble, getMdaHelper as getMda, setMdaAtPath } from './components/scriptRunner/actions/getMda/getMda';
+export { loadEnsemble, getMdaHelper as getMda, setMdaAtPath, getNamespace } from './components/scriptRunner/actions/getMda/getMda';
 export {
 	default as morphConfig, fixScopeIds
 } from './components/scriptRunner/helpers/morphConfig';
@@ -62,7 +62,7 @@ export { resolveThemeAccessor } from './system/managers/themeManager';
 
 export { default as useEffectSkipFirst } from './system/customHooks/useEffectSkipFirst';
 
-export { getScopedId, getDom } from './system/managers/scopeManager';
+export { getScopedId, getDom, getNodeNamespace } from './system/managers/scopeManager';
 
 export { default as propsSharedContainer } from './components/container/propsShared';
 

--- a/src/library/loadApp.js
+++ b/src/library/loadApp.js
@@ -11,7 +11,7 @@ import { init as initComponentManager,
 	registerExternalTypes,
 	applyPropSpecDefaults } from '../system/managers/componentManager';
 import { init as initEventManager } from '../system/managers/eventManager';
-import { setMdaPackage, getMdaHelper } from '../components/scriptRunner/actions/getMda/getMda';
+import { setMdaPackage, getMdaHelper, getMdaPackage } from '../components/scriptRunner/actions/getMda/getMda';
 import createFlow from '../components/scriptRunner/actions/createFlow';
 import { init as initThemeManager } from '../system/managers/themeManager';
 import applyThemesToMdaPackage from '../app/components/helpers/applyThemesToMdaPackage';
@@ -120,7 +120,10 @@ const onMount = (
 		theme
 	});
 
-	applyThemesToMdaPackage(mdaPackage);
+	//We need to load it again because the setMdaPackage function clones the contents of the package into an existing object
+	const finalMdaPackage = getMdaPackage();
+
+	applyThemesToMdaPackage(finalMdaPackage);
 	applyPropSpecDefaults();
 
 	const startupDashboard = getMdaHelper({

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,55 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
-import Opus, { Component } from './library';
+import Opus, { ThemedComponent, loadEnsemble, buildThemes, applyThemesToMdaPackage, getMdaPackage } from './library';
+
+const onMount = () => {
+	loadEnsemble({
+		name: 'a',
+		ensemble: {
+			dashboard: {},
+			themes: {
+				'a.json': {
+					b: '#FF0000'
+				}
+			}
+		}
+	});
+
+	buildThemes({ themes: ['a'], themeSets: [] })
+
+	const mdaPackage = getMdaPackage();
+	applyThemesToMdaPackage(mdaPackage);
+};
 
 const OpusUI = () => {
+	useEffect(onMount, []);
+
 	return (
 		<div>
-			<Component mda={{
-				type: 'label',
-				prps: { caption: 'Opus UI: Hit the perfect pitch between traditional development and low-code' }
+			<ThemedComponent mda={{
+				type: 'container',
+				prps: {
+					canClick: true,
+					fireScript: {
+						actions: [{
+							type: 'setState',
+							key: 'extraWgts',
+							value: [{
+								type: 'label',
+								prps: {
+									caption: 'yo',
+									backgroundColor: '{theme.a.b}'
+								}
+							}]
+						}]
+					}
+				},
+				wgts: [{
+					type: 'label',
+					prps: {
+						caption: 'click me'
+					}
+				}]
 			}} />
 		</div>
 	);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,80 +1,26 @@
-import React, { useEffect } from 'react';
+//React
 import { createRoot } from 'react-dom/client';
-import Opus, { ThemedComponent, loadEnsemble, buildThemes, applyThemesToMdaPackage, getMdaPackage } from './library';
 
-const onMount = () => {
-	loadEnsemble({
-		name: 'a',
-		ensemble: {
-			dashboard: {},
-			themes: {
-				'a.json': {
-					b: '#FF0000'
-				}
-			}
-		}
-	});
+//System
+import Opus, { Component } from './library';
 
-	buildThemes({ themes: ['a'], themeSets: [] })
-
-	const mdaPackage = getMdaPackage();
-	applyThemesToMdaPackage(mdaPackage);
-};
-
+//Custom Component
 const OpusUI = () => {
-	useEffect(onMount, []);
-
 	return (
 		<div>
-			<ThemedComponent mda={{
-				type: 'container',
-				prps: {
-					canClick: true,
-					fireScript: {
-						actions: [{
-							type: 'setState',
-							key: 'extraWgts',
-							value: [{
-								type: 'label',
-								prps: {
-									caption: 'yo',
-									backgroundColor: '{theme.a.b}'
-								}
-							}]
-						}]
-					}
-				},
-				wgts: [{
-					type: 'label',
-					prps: {
-						caption: 'click me'
-					}
-				}]
+			<Component mda={{
+				type: 'label',
+				prps: { caption: 'Opus UI: Hit the perfect pitch between traditional development and low-code' }
 			}} />
 		</div>
 	);
 };
 
-const Label = ({ state: { caption } }) => {
-	return (
-		<span>{caption}</span>
-	);
-};
-
+//Setup
 const root = createRoot(document.getElementById('root'));
 
 root.render(
 	<Opus
 		startupComponent={<OpusUI />}
-		registerComponentTypes={[{
-			type: 'label',
-			component: Label,
-			propSpec: {
-				caption: {
-					type: 'string',
-					dft: ''
-				}
-			}
-		}]}
 	/>
 );

--- a/src/props/cssMaps/mapToColor.js
+++ b/src/props/cssMaps/mapToColor.js
@@ -1,5 +1,13 @@
+import { getNodeNamespace, getNamespace } from '../../library';
+
 const mapToColor = (propVal, fullState, propConfig, themes) => {
-	const { mapToTheme = 'colors' } = propConfig;
+	let { mapToTheme = 'colors' } = propConfig;
+
+	const namespaceName = getNodeNamespace(fullState.id);
+	if (namespaceName) {
+		const namespace = getNamespace(namespaceName);
+		mapToTheme = namespace.themeOverrides[mapToTheme] ?? mapToTheme;
+	}
 
 	const keyExists = themes?.[mapToTheme]?.[propVal] !== undefined;
 

--- a/src/props/cssMaps/mapToSize.js
+++ b/src/props/cssMaps/mapToSize.js
@@ -1,8 +1,16 @@
+import { getNodeNamespace, getNamespace } from '../../library';
+
 const mapToSize = (propVal, fullState, propConfig, themes) => {
-	const { mapToTheme = 'global' } = propConfig;
+	let { mapToTheme = 'global' } = propConfig;
 
 	if (!propVal.split)
 		return propVal;
+
+	const namespaceName = getNodeNamespace(fullState.id);
+	if (namespaceName) {
+		const namespace = getNamespace(namespaceName);
+		mapToTheme = namespace.themeOverrides[mapToTheme] ?? mapToTheme;
+	}
 
 	const result = propVal
 		.split(' ')

--- a/src/system/managers/componentManager.js
+++ b/src/system/managers/componentManager.js
@@ -90,6 +90,8 @@ export const getPropSpecs = () => propSpecs;
 
 export const doesComponentTypeExist = type => !!components[type];
 
+export const getComponentTypes = () => Object.keys(components);
+
 export const init = () => {
 	initSetWgtState({ getPropSpec });
 	initGetListenerStates({ getPropSpec });

--- a/src/system/managers/eventManager.js
+++ b/src/system/managers/eventManager.js
@@ -30,6 +30,17 @@ const onKeyDown = e => {
 		e.preventDefault();
 };
 
+const onKeyUp = e => {
+	if (e.target.localName !== 'body')
+		return;
+
+	//Source is undefined so event will be global
+	const consumed = emitEvent(undefined, 'onGlobalKeyUp', e);
+	if (consumed)
+		e.preventDefault();
+};
+
 export const init = () => {
 	document.addEventListener('keydown', onKeyDown);
+	document.addEventListener('keyup', onKeyUp);
 };

--- a/src/system/managers/scopeManager.js
+++ b/src/system/managers/scopeManager.js
@@ -193,7 +193,7 @@ const addNodeToDomTree = node => {
 };
 
 export const addNodeToDom = mda => {
-	const { id, relId, parentId, scope } = mda;
+	const { id, relId, parentId, scope, namespace } = mda;
 
 	const exists = findNodeInDomTree(id);
 	if (exists)
@@ -231,7 +231,8 @@ export const addNodeToDom = mda => {
 		ownScopes,
 		parentScopeOwners,
 		childNodesWithRelIds,
-		cachedInParents
+		cachedInParents,
+		namespace
 	};
 
 	dom.push(node);
@@ -427,3 +428,12 @@ export const isIdInDom = id => {
 };
 
 export const getDom = () => dom;
+
+export const getNodeNamespace = id => {
+	let node = dom.find(d => d.id === id);
+
+	while (node !== undefined && !node.namespace)
+		node = node.parentNode;
+
+	return node?.namespace;
+};


### PR DESCRIPTION
# Breaking Changes
* getComponentAtPosition no longer includes popover components. Theoretically breaking but nobody except builder is using it at the moment

# Features
* Namespaces
* onGlobalKeyUp trigger
* Child components now have an `indexInParent` key in their state
* Various new exports added to `library`

# Enhancements
* loadEnsemble can now also load themes