### PR TITLE
Fix store reset length

### DIFF
--- a/src/system/managers/flowManager/stores/storeEvents.js
+++ b/src/system/managers/flowManager/stores/storeEvents.js
@@ -76,5 +76,5 @@ export const addEventEntry = (listener, value) => {
 };
 
 export const resetEvents = () => {
-	store.length = [];
+       store.length = 0;
 };

--- a/src/system/managers/flowManager/stores/storeListeners.js
+++ b/src/system/managers/flowManager/stores/storeListeners.js
@@ -228,7 +228,7 @@ export const resetListenerValuesForScope = scope => {
 };
 
 export const resetListeners = () => {
-	store.length = [];
+       store.length = 0;
 };
 
 export const destroyListener = listener => {


### PR DESCRIPTION
## Summary
- fix length reset in storeEvents
- fix length reset in storeListeners

## Testing
- `npm test` *(fails: needs interactive playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_683fedcbc3108322b927a5bc0e16eb93