### PR TITLE
Fix hex conversions

### DIFF
--- a/src/system/managers/themeManager/convertHexToHsl.js
+++ b/src/system/managers/themeManager/convertHexToHsl.js
@@ -1,6 +1,11 @@
 const convertHexToHsl = hex => {
-	// Convert hex to RGB first
-	let r = '0x' + hex[1] + hex[2];
+       // Expand shorthand hex ("#abc") to "#aabbcc" so the RGB conversion
+       // logic works reliably across environments
+       if (hex.length === 4 && hex[0] === '#')
+               hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+
+        // Convert hex to RGB first
+        let r = '0x' + hex[1] + hex[2];
 	let g = '0x' + hex[3] + hex[4];
 	let b = '0x' + hex[5] + hex[6];
 	// Then to HSL

--- a/src/system/managers/themeManager/convertHexToRgb.js
+++ b/src/system/managers/themeManager/convertHexToRgb.js
@@ -1,8 +1,10 @@
 const convertHexToRgb = hex => {
-	if (hex.length < 7)
-		hex = hex.padEnd(7, '0');
+       // Expand shorthand hex codes (e.g., "#abc") to the full form "#aabbcc"
+       // so the RGB conversion is consistent across browsers
+       if (hex.length === 4 && hex[0] === '#')
+               hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
 
-	const m = hex.match(/^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
+        const m = hex.match(/^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i);
 
 	return [
 		parseInt(m[1], 16),


### PR DESCRIPTION
## Summary
- support shorthand hex (`#abc` -> `#aabbcc`) in `convertHexToRgb` and `convertHexToHsl`
- remove braces around single-line hex expansion for style

## Testing
- `npm test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fee2aff888322a32f508062691b97