### PR TITLE
Fix applyExtraProps formatter lookup

### DIFF
--- a/src/system/wrapper/helpers/applyExtraProps.js
+++ b/src/system/wrapper/helpers/applyExtraProps.js
@@ -13,22 +13,24 @@ const formatDate = () => {
 };
 
 const applyExtraProps = props => {
-	const { cpt } = props;
+        const { cpt } = props;
 
-	if (
-		!cpt ||
-		!cpt.substr ||
+        if (
+                !cpt ||
+                !cpt.substr ||
         cpt.substr(0, 1) !== '{' ||
         cpt.substr(-1, 1) !== '}' ||
         !cpt.includes('{extra.')
-	)
-		return;
+        )
+                return;
 
-	const useFormat = cpt.split('{extra.')[1].replace('}', '');
+        const useFormat = cpt.split('{extra.')[1].replace('}', '');
 
-	const useCpt = { currentDate: formatDate }[useFormat](props);
+        const formatters = { currentDate: formatDate };
+        const formatterFn = formatters[useFormat];
 
-	props.cpt = useCpt;
+        if (typeof formatterFn === 'function')
+                props.cpt = formatterFn(props);
 };
 
 export default applyExtraProps;


### PR DESCRIPTION
## Summary
- avoid invoking undefined formatter in `applyExtraProps`

## Testing
- `npm test` *(fails: Cannot find package '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_683fee1f70c88322bb3b0322be2e43bd