### PR TITLE
PF-6880 — fix comparison operators collapsing objects to "[object Obj…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
 	"files": [

--- a/src/components/scriptRunner/actions/applyComparison/comparisons.js
+++ b/src/components/scriptRunner/actions/applyComparison/comparisons.js
@@ -1,5 +1,7 @@
 const isNil = v => v === null || v === undefined;
 
+const isObj = v => typeof(v) === 'object' && v !== null;
+
 const toStr = v => {
 	if (isNil(v))
 		return '';
@@ -15,21 +17,39 @@ const toNum = v => {
 	return Number.isNaN(n) ? undefined : n;
 };
 
+//Deep structural equality. Containers are compared key/element-wise; leaves fall back to the
+// same loose, case-insensitive rule as isEqual. This is needed because String()-coercing an
+// object yields "[object Object]" for EVERY object — so toLower/toStr-based comparisons treat
+// any two objects as equal (and as "containing" each other). Deep-compare instead so distinct
+// object values (e.g. two colour preferences) are correctly seen as different.
+const deepEqual = (a, b) => {
+	if (a === b)
+		return true;
+
+	//At least one side is a primitive: only equal if BOTH are primitives that loosely match.
+	if (!isObj(a) || !isObj(b))
+		return !isObj(a) && !isObj(b) && toLower(a) === toLower(b);
+
+	if (Array.isArray(a) !== Array.isArray(b))
+		return false;
+
+	const keys = Object.keys(a);
+	if (keys.length !== Object.keys(b).length)
+		return false;
+
+	return keys.every(k => deepEqual(a[k], b[k]));
+};
+
 export const isEqual = (a, b) => {
 	if (isNil(a) || isNil(b))
 		return a === b;
 
-	return toLower(a) === toLower(b);
+	return deepEqual(a, b);
 };
 
 export const isEqualCase = (a, b) => a === b;
 
-export const isNotEqual = (a, b) => {
-	if (isNil(a) || isNil(b))
-		return a !== b;
-
-	return toLower(a) !== toLower(b);
-};
+export const isNotEqual = (a, b) => !isEqual(a, b);
 
 export const isFalsy = a => (
 	a === null || a === undefined || a === '' || a === 0 || a === false
@@ -108,8 +128,17 @@ export const isBetweenInclusive = (a, b) => {
 	return b1 <= val && b2 >= val;
 };
 
+//`a` contains `b`. Arrays test membership (deep/loose per element); strings test substring.
+// An object operand can't be a meaningful substring, so guard against the "[object Object]"
+// collapse that would otherwise report any two objects as containing each other.
 export const doesContain = (a, b) => {
 	if (isNil(a) || isNil(b))
+		return false;
+
+	if (Array.isArray(a))
+		return a.some(el => isEqual(el, b));
+
+	if (isObj(a) || isObj(b))
 		return false;
 
 	return toLower(a).includes(toLower(b));
@@ -117,12 +146,7 @@ export const doesContain = (a, b) => {
 
 export const doesNotContain = (a, b) => !doesContain(a, b);
 
-export const containedIn = (a, b) => {
-	if (isNil(a) || isNil(b))
-		return false;
-
-	return toLower(b).includes(toLower(a));
-};
+export const containedIn = (a, b) => doesContain(b, a);
 
 export const notContainedIn = (a, b) => !containedIn(a, b);
 
@@ -130,17 +154,18 @@ export const doesContainCase = (a, b) => {
 	if (isNil(a) || isNil(b))
 		return false;
 
+	if (Array.isArray(a))
+		return a.some(el => isEqualCase(el, b));
+
+	if (isObj(a) || isObj(b))
+		return false;
+
 	return toStr(a).includes(toStr(b));
 };
 
 export const doesNotContainCase = (a, b) => !doesContainCase(a, b);
 
-export const containedInCase = (a, b) => {
-	if (isNil(a) || isNil(b))
-		return false;
-
-	return toStr(b).includes(toStr(a));
-};
+export const containedInCase = (a, b) => doesContainCase(b, a);
 
 export const notContainedInCase = (a, b) => !containedInCase(a, b);
 


### PR DESCRIPTION
…ect]"

isEqual/isNotEqual and the contains operators coerced every value with String()/toLowerCase(), so any two objects compared as "[object Object]" === "[object Object]" and were treated as equal (and as containing each other).

This broke object-valued preferences (e.g. Background Color): the onFieldChanged stopScript guard saw the new colour as "equal" to the stored one and aborted before writing, so the app background never updated on the newer engine (dev).

- isEqual/isNotEqual: deep structural equality for objects/arrays; primitives keep the null-safe, case-insensitive compare.
- doesContain/containedIn (+Case): arrays test membership, strings test substring, object operands no longer spuriously match via the "[object Object]" collapse.

Bumped version 3.1.1 -> 3.1.2.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
