### PR TITLE
fix: remove unused indexInParent prop mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
 	"files": [

--- a/src/components/wrapWidgets.jsx
+++ b/src/components/wrapWidgets.jsx
@@ -78,11 +78,9 @@ const findComponentTraitIndex = traits => {
 };
 
 const wrapWidgets = ({ ChildWgt, wgts = [] }) => {
-	const result = wgts.map((w, i) => {
+	const result = wgts.map(w => {
 		if (!w.prps)
 			w.prps = {};
-
-		w.prps.indexInParent = i;
 
 		if (typeof(w.type) !== 'function') {
 			const componentTraitIndex = findComponentTraitIndex(w.traits);


### PR DESCRIPTION
wrapWidgets stamped `indexInParent` onto every child's live prps object. Nothing in opus-ui consumes it (it was only surfaced in the devtools panel), but the in-place mutation meant a child's metadata changed whenever its position in the parent shifted. mdaChanged then flagged the node as changed, bumping mdaVersion and forcing WrapperDynamic to re-apply traits and re-derive the whole subtree from scratch — remounting it and dropping its state. This showed up as a tab reloading (and losing its active sub-tab, grid state, etc.) when an earlier sibling tab was closed and the survivor's index shifted. Removing the mutation.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
