### PR TITLE
Use npm trusted publishing and Node 24

### DIFF
--- a/.github/workflows/ci-remote-repos.yml
+++ b/.github/workflows/ci-remote-repos.yml
@@ -18,7 +18,7 @@ jobs:
         ]
     steps:
       - name: Dispatch to ${{ matrix.repo }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PAT_REMOTE_DISPATCH }}
           repository: ${{ matrix.repo }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
-        node-version: lts/*
+        node-version: '24'
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   build-publish-tag:
     runs-on: ubuntu-latest
@@ -12,17 +16,17 @@ jobs:
     steps:
       # 1) Check out the full history so we can push tags later
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      # 2) Set up Node.js (latest LTS) and configure npm to use the official registry
+      # 2) Set up Node.js and configure npm to use the official registry
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: true
+          package-manager-cache: false
 
       # 3) Read version from package.json into an environment variable
       - name: Get package version
@@ -50,8 +54,6 @@ jobs:
 
       # 8) Publish to npm (will fail the job if publish fails)
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           echo "Publishing version $VERSION to npm..."
           npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@intenda/opus-ui",
-			"version": "3.1.5",
+			"version": "3.1.6",
 			"dependencies": {
 				"@floating-ui/react": "^0.27.5",
 				"@floating-ui/react-dom": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
 	"files": [


### PR DESCRIPTION
## What changed

- authenticate `npm publish` through npm Trusted Publishing (OIDC) instead of the `NPM_TOKEN` repository secret
- grant the publish workflow `id-token: write` and retain `contents: write` for its version tag push
- update `actions/checkout` and `actions/setup-node` to v6 and pin workflow execution to Node.js 24
- update `peter-evans/repository-dispatch` to v4, which uses the Node.js 24 action runtime
- remove the deprecated `always-auth` setup-node input
- bump `@intenda/opus-ui` from 3.1.5 to 3.1.6

## Why

npm is retiring long-lived bypass-2FA publishing tokens in favor of Trusted Publishing. GitHub has also moved current JavaScript actions to the Node.js 24 runtime. This updates the release path before the older runtimes and token flow become unavailable.

## Impact

After this PR is merged, the main-branch release workflow will test and build the package, publish version 3.1.6 using the configured npm trusted publisher, and create tag `v3.1.6` after a successful publish. The `NPM_TOKEN` secret is no longer read by the workflow.

## Validation

- confirmed npm currently reports `@intenda/opus-ui` version 3.1.5, so 3.1.6 is available
- parsed all GitHub workflow YAML successfully
- parsed `package.json` and `package-lock.json` successfully
- ran `git diff --check`
- local build and Playwright tests were not run, per workspace verification policy; the PR workflows will exercise the Node.js 24 CI path