### PR TITLE
Fix npm provenance and avoid duplicate release tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 jobs:
   test:
     timeout-minutes: 60

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
 	"version": "3.1.6",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/IntendaUK/opus-ui"
+	},
 	"files": [
 		"dist",
 		"lspconfig.json"


### PR DESCRIPTION
## What changed

- add the public `IntendaUK/opus-ui` repository URL to `package.json`, allowing npm to validate the automatically generated trusted-publishing provenance
- make the standalone Playwright workflow run only for pull requests targeting `main`
- retain Playwright execution in the main-branch publish workflow, so merged or direct main pushes are tested once before publishing

## Why

The 3.1.6 trusted publish authenticated and signed successfully, but npm rejected it because `package.json` had no `repository.url` to match against the GitHub provenance. In addition, pushes to `main` were running Playwright once in the CI workflow and again in the publish workflow.

## Impact

Merging this PR will retry publication of the still-available version 3.1.6. Pull requests continue to receive Playwright validation; the merge commit is then tested once by the publish workflow before build, publish, and tag creation.

## Validation

- parsed `package.json` successfully and verified the repository metadata through `npm pkg get`
- parsed the updated workflow YAML successfully
- ran `git diff --check`
- npm currently reports 3.1.5 as `latest`, so 3.1.6 remains available for the retry
- local build and Playwright tests were not run, per workspace verification policy; the PR workflow will run Playwright on Node.js 24