### PR TITLE
Publish Opus 2 through trusted publishing

### DIFF
--- a/.github/workflows/ci-remote-repos.yml
+++ b/.github/workflows/ci-remote-repos.yml
@@ -3,10 +3,10 @@ name: Run CI on Remote Repos
 on:
   push:
     branches:
-      - main
+      - opus-2
   pull_request:
     branches:
-      - main
+      - opus-2
 
 jobs:
   dispatch-remote:
@@ -18,7 +18,7 @@ jobs:
         ]
     steps:
       - name: Dispatch to ${{ matrix.repo }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PAT_REMOTE_DISPATCH }}
           repository: ${{ matrix.repo }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,16 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ opus-2 ]
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
-        node-version: lts/*
+        node-version: '24'
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -3,7 +3,11 @@ name: Test, Build, Publish, and Tag
 on:
   push:
     branches:
-      - main
+      - opus-2
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
   build-publish-tag:
@@ -12,17 +16,17 @@ jobs:
     steps:
       # 1) Check out the full history so we can push tags later
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      # 2) Set up Node.js (latest LTS) and configure npm to use the official registry
+      # 2) Set up Node.js and configure npm to use the official registry
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 'lts/*'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: true
+          package-manager-cache: false
 
       # 3) Read version from package.json into an environment variable
       - name: Get package version
@@ -50,11 +54,9 @@ jobs:
 
       # 8) Publish to npm (will fail the job if publish fails)
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "Publishing version $VERSION to npm..."
-          npm publish
+          echo "Publishing version $VERSION to npm with the opus-2 tag..."
+          npm publish --tag opus-2
 
       # 9) Create and push the Git tag only if the publish step succeeded
       - name: Create and push tag if not exists

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "2.7.3",
+	"version": "2.7.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@intenda/opus-ui",
-			"version": "2.7.3",
+			"version": "2.7.4",
 			"dependencies": {
 				"@floating-ui/react": "^0.27.5",
 				"@floating-ui/react-dom": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
 	"name": "@intenda/opus-ui",
-	"version": "2.7.3",
+	"version": "2.7.4",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/IntendaUK/opus-ui"
+	},
 	"files": [
 		"dist",
 		"lspconfig.json"


### PR DESCRIPTION
## What changed

- make the Opus 2 release workflow run on pushes to the `opus-2` branch instead of `main`
- authenticate npm publishing through the configured Trusted Publisher (OIDC), removing the `NPM_TOKEN` dependency
- publish Opus 2 with `npm publish --tag opus-2`, preserving Opus 3 as npm's `latest` channel
- add the repository metadata required for automatic provenance verification
- move all workflow action runtimes and test execution to Node.js 24 (`checkout@v6`, `setup-node@v6`, and `repository-dispatch@v4`)
- make standalone Playwright CI run only for pull requests targeting `opus-2`; the release workflow runs Playwright once after merge before publishing
- bump the Opus 2 package version from 2.7.3 to 2.7.4

## Why

The Opus 2 branch's workflows were still configured for `main`, so the branch could not publish its own releases. The release also used the retiring npm token flow and would have published to the default `latest` dist-tag, potentially replacing the Opus 3 channel.

## Impact

Merging this PR into `opus-2` will test, build, publish `@intenda/opus-ui@2.7.4` under the `opus-2` npm dist-tag, and create tag `v2.7.4` only after a successful publish. The `latest` tag remains reserved for Opus 3.

## Validation

- confirmed npm currently maps `latest` to 3.1.5 and `opus-2` to 2.7.3
- confirmed 2.7.4 is not yet published
- parsed all workflow YAML and package JSON successfully
- verified the package version and repository metadata through `npm pkg get`
- ran `git diff --check`
- local build and Playwright tests were not run, per workspace verification policy; the post-merge Opus 2 release workflow will run them on Node.js 24 before publishing