### PR TITLE
Target main component CI explicitly

### DIFF
--- a/.github/workflows/ci-remote-repos.yml
+++ b/.github/workflows/ci-remote-repos.yml
@@ -26,5 +26,6 @@ jobs:
           client-payload: |
             {
               "ref": "${{ github.ref }}",
-              "sha": "${{ github.sha }}"
+              "sha": "${{ github.sha }}",
+              "target_branch": "main"
             }


### PR DESCRIPTION
## What changed

- add `target_branch: main` to the repository-dispatch payload sent to `IntendaUK/opus-ui-components`

## Why

GitHub runs `repository_dispatch` workflows from the target repository's default branch. An explicit target is needed so the components workflow can select the correct release line for both normal branch pushes and pull-request dispatches, whose `github.ref` is otherwise only `refs/pull/.../merge`.

## Impact

Opus UI main pull requests and pushes will test against `opus-ui-components/main`. This is consumed by the companion components PR #12.

## Validation

- parsed the workflow YAML successfully
- validated the JSON payload structure
- ran `git diff --check`
- no local test suite was run because this changes dispatch metadata only