### PR TITLE
Skip already-published Opus UI versions

### DIFF
--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -52,11 +52,22 @@ jobs:
       - name: Build project
         run: npm run build
 
-      # 8) Publish to npm (will fail the job if publish fails)
-      - name: Publish to npm
+      # 8) Publish only when this exact version is not already on npm
+      - name: Publish to npm if version is new
         run: |
-          echo "Publishing version $VERSION to npm..."
-          npm publish
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_SPEC="${PACKAGE_NAME}@${VERSION}"
+
+          if npm view "$PACKAGE_SPEC" version --json >/dev/null 2>&1; then
+            echo "$PACKAGE_SPEC is already published. Skipping npm publish."
+          elif npm publish; then
+            echo "Published $PACKAGE_SPEC."
+          elif npm view "$PACKAGE_SPEC" version --json >/dev/null 2>&1; then
+            echo "$PACKAGE_SPEC was published by another workflow. Continuing."
+          else
+            echo "Failed to publish $PACKAGE_SPEC."
+            exit 1
+          fi
 
       # 9) Create and push the Git tag only if the publish step succeeded
       - name: Create and push tag if not exists


### PR DESCRIPTION
## What changed

- check npm for the exact `@intenda/opus-ui` package version before attempting publication
- skip `npm publish` successfully when that version already exists
- recheck npm after a publish failure to handle concurrent workflows racing to publish the same version
- continue to the existing idempotent Git tag step when publication is skipped
- retain failures for genuine authentication, registry, or publish errors when the version does not exist

## Why

Every push to `main` runs the release workflow. A workflow-only commit therefore attempted to republish unchanged version 3.1.6, causing an expected npm version-conflict failure and an unnecessary notification.

## Impact

Repeated release workflow runs for an unchanged version complete successfully without attempting to overwrite npm. New versions still publish normally, and `vX.Y.Z` tags are still created after the version is confirmed on npm.

## Validation

- parsed the workflow YAML successfully
- ran `git diff --check`
- confirmed 3.1.6 already exists on npm, exercising the intended skip condition conceptually
- the PR's Playwright workflow validates the codebase independently